### PR TITLE
strip ':' from 'Category:' page name prefix

### DIFF
--- a/m2c/cli.py
+++ b/m2c/cli.py
@@ -232,7 +232,7 @@ def parse_space(page):
 def parse_title(page):
     """Parse the title of the page."""
     if 'Category:' in page.name:
-        return page.name.replace('Category', '')
+        return page.name.replace('Category:', '')
     return page.name
 
 
@@ -834,3 +834,7 @@ def category_pages(undo, verbose, limit, debug):
             )
 
         click.echo(output)
+
+if __name__ == '__main__':
+    import sys
+    page(sys.argv[1:])

--- a/m2c/dummy.py
+++ b/m2c/dummy.py
@@ -1,0 +1,21 @@
+import io
+import unicodedata
+import os
+from itertools import chain
+from os import environ
+from os.path import abspath, dirname
+from pprint import pprint
+from subprocess import STDOUT, CalledProcessError, check_output
+from uuid import uuid4
+
+import click
+import requests
+from bs4 import BeautifulSoup
+
+import mwclient
+import panflute
+import pypandoc
+
+
+click.echo('Could not do that Dave.')
+print("hello world")


### PR DESCRIPTION
fix strip ':' from 'Category:' page name prefix.
Also add dumb parameter handling when called direct from script.